### PR TITLE
query to data

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
-module.exports = require('./lib/SwormSchema')
+module.exports.Schema = require('./lib/SwormSchema')
+module.exports.Query = require('./lib/SwormQuery')

--- a/lib/SwormQuery.js
+++ b/lib/SwormQuery.js
@@ -1,3 +1,4 @@
+const flatten = require('lowscore/flatten')
 const groupBy = require('lowscore/groupBy')
 const indexBy = require('lowscore/indexBy')
 const uniq = require('lowscore/uniq')
@@ -43,6 +44,18 @@ module.exports = class SwormQuery {
         tables[table.alias] = table.name
       })
 
+    const requiredColumns = flatten(Object.keys(tables).map(tableAlias => {
+      const tableName = tables[tableAlias]
+      const table = this.schema[tableName]
+      const requiredColumns = Object.keys(table).map(columnName => {
+        const column = table[columnName]
+        if (column.primaryKey || !column.null) {
+          return {tableName, tableAlias, columnName}
+        }
+      }).filter(c => c)
+
+      return requiredColumns
+    }))
 
     this.tables = tables
     this.columns = columns
@@ -57,6 +70,23 @@ module.exports = class SwormQuery {
         tableAlias,
       }
     })
+    const missing = requiredColumns.filter(required => {
+      return !this.mappings.find(column =>
+        column.tableAlias === required.tableAlias &&
+        column.column === required.columnName
+       )
+    })
+
+    missing.forEach(column => {
+      const alias = `column${this.mappings.length+1}`
+      this.mappings.push({
+        sql: `${column.tableAlias}.${column.columnName} as "${alias}"`,
+        column: column.columnName.toLowerCase(),
+        table: column.tableName,
+        tableAlias: column.tableAlias,
+        alias,
+      })
+    })
   }
 
   asFetchAll () {
@@ -67,9 +97,9 @@ module.exports = class SwormQuery {
       .join('\n')
   }
 
-  async fetchData (db) {
+  async fetchData (db, params) {
     this.analyse()
-    const results = await db.query(this.asFetchAll())
+    const results = await db.query(this.asFetchAll(), params)
 
     const tables = {}
     results.forEach(row => {
@@ -102,7 +132,9 @@ module.exports = class SwormQuery {
         name: column,
         primaryKey: tableDefinition[column].primaryKey,
       }))
-      const primaryKey = columnDefinitions.find(column => column.primaryKey).name
+      const primaryColumn = columnDefinitions.find(column => column.primaryKey)
+      if (!primaryColumn) throw new Error(`No primaryKey defined for table ${tableName}`)
+      const primaryKey = primaryColumn.name
       const rowGroups = groupBy(rows, table => {
         return table.columns[primaryKey]
       })

--- a/lib/SwormQuery.js
+++ b/lib/SwormQuery.js
@@ -1,0 +1,118 @@
+const groupBy = require('lowscore/groupBy')
+const indexBy = require('lowscore/indexBy')
+const uniq = require('lowscore/uniq')
+const compact = require('lowscore/compact')
+const sqliteParser = require('sqlite-parser')
+
+module.exports = class SwormQuery {
+  constructor ({schema, query}) {
+    this.schema = schema
+    this.query = query
+    this.ast = sqliteParser(query)
+  }
+
+  analyse () {
+    const identifiers = []
+
+    function findIdentifiers(obj) {
+      if (obj.type === 'identifier') {
+        identifiers.push(obj)
+      } else  {
+        const children = Object.values(obj)
+        children.forEach(child => {
+          if (typeof child === 'object') {
+            findIdentifiers(child)
+          }
+        })
+      }
+    }
+
+    findIdentifiers(this.ast)
+    this.identifiers = identifiers
+
+    const columns = identifiers
+      .filter(identifier => identifier.variant === 'column')
+      .map(identifier => identifier.name)
+      .sort()
+
+
+    const tables = {}
+    identifiers
+      .filter(ident => ident.variant === 'table')
+      .forEach(table => {
+        tables[table.alias] = table.name
+      })
+
+
+    this.tables = tables
+    this.columns = columns
+    this.mappings = columns.map((fullColumnName, index) => {
+      const tableAlias = fullColumnName.substring(0, fullColumnName.indexOf('.'))
+      const column = fullColumnName.substring(fullColumnName.indexOf('.')+1)
+      return {
+        sql: `${fullColumnName} as "column${index}"`,
+        column,
+        alias: `column${index}`,
+        table: tables[tableAlias],
+        tableAlias,
+      }
+    })
+  }
+
+  asFetchAll () {
+    const columns = this.mappings.map(column => column.sql).join(', ')
+    return this.query.replace(/select[\s\S]*?from/i, `select ${columns}\nfrom`)
+      .split('\n')
+      .map(line => line.trim())
+      .join('\n')
+  }
+
+  async fetchData (db) {
+    this.analyse()
+    const results = await db.query(this.asFetchAll())
+
+    const tables = {}
+    results.forEach(row => {
+      const newRow = {}
+      const tableColumns = {}
+      Object.keys(row).forEach(alias => {
+        const mapping = this.mappings.find(m => m.alias === alias)
+        tableColumns[mapping.tableAlias] = tableColumns[mapping.tableAlias] || {
+          table: mapping.table,
+          columns: {},
+        }
+        tableColumns[mapping.tableAlias].columns[mapping.column] = row[alias]
+      })
+
+      Object.values(tableColumns).forEach(tableEntry => {
+        const columns = compact(Object.values(tableEntry.columns))
+        if (columns.length > 0) {
+          const name = tableEntry.table
+          tables[name] = tables[name] || []
+          tables[name].push(tableEntry)
+        }
+      })
+    })
+
+    const mergedEntries = []
+    Object.keys(tables).forEach(tableName => {
+      const rows = tables[tableName]
+      const tableDefinition = this.schema[tableName]
+      const columnDefinitions = Object.keys(tableDefinition).map(column => ({
+        name: column,
+        primaryKey: tableDefinition[column].primaryKey,
+      }))
+      const primaryKey = columnDefinitions.find(column => column.primaryKey).name
+      const rowGroups = groupBy(rows, table => {
+        return table.columns[primaryKey]
+      })
+
+      Object.values(rowGroups).forEach(rows => {
+        const row = Object.assign.apply(null, rows)
+        mergedEntries.push(row)
+      })
+    })
+
+    return mergedEntries
+  }
+}

--- a/lib/querySchema.js
+++ b/lib/querySchema.js
@@ -49,20 +49,24 @@ module.exports = function (query) {
   const columns = identifiers
     .filter(ident => ident.variant === 'column')
     .map(column => {
+      let alias = ''
       let table = ''
       let name = column.name
       const nameParts = column.name.split('.')
 
       if (nameParts.length === 2) {
-        table = nameParts[0]
+        alias = nameParts[0]
         name = nameParts[1]
       }
-      if (aliasToTable[table]) {
-        table = aliasToTable[table].name
+      if (aliasToTable[alias]) {
+        table = aliasToTable[alias].name
+      } else {
+        table = alias
       }
       return {
         table,
         name,
+        alias,
       }
     })
 

--- a/test/SwormQuerySpec.js
+++ b/test/SwormQuerySpec.js
@@ -1,0 +1,117 @@
+require('./cleanup')
+const SwormSchema = require('../')
+const SwormQuery = require('../lib/SwormQuery')
+const assert = require('assert')
+
+describe('SwormQuery', () => {
+  it('lists all the columns that are used in the query including original aliases', () => {
+    const query = new SwormQuery({query: `
+      select p.name, o.name
+      from people p inner join
+      orgs o on p.id = o.id
+    `})
+
+    query.analyse()
+
+    assert.deepEqual(query.tables, {
+      'o': 'orgs',
+      'p': 'people',
+    })
+
+    assert.deepEqual(query.columns, [
+      'o.id',
+      'o.name',
+      'p.id',
+      'p.name',
+    ])
+
+    assert.deepEqual(query.mappings, [
+      {
+        sql: 'o.id as "column0"',
+        column: 'id',
+        alias: 'column0',
+        table: 'orgs',
+        tableAlias: 'o',
+      },
+      {
+        sql: 'o.name as "column1"',
+        column: 'name',
+        alias: 'column1',
+        table: 'orgs',
+        tableAlias: 'o',
+      },
+      {
+        sql: 'p.id as "column2"',
+        column: 'id',
+        alias: 'column2',
+        table: 'people',
+        tableAlias: 'p',
+      },
+      {
+        sql: 'p.name as "column3"',
+        column: 'name',
+        alias: 'column3',
+        table: 'people',
+        tableAlias: 'p',
+      },
+    ])
+  })
+
+  it('creates a query with all of the join data in the select statement', () => {
+    const query = new SwormQuery({query: `
+      select p.name, o.name
+      from people p inner join
+      orgs o on p.id = o.id
+    `})
+
+    query.analyse()
+
+    assert.equal(query.asFetchAll(), `
+select o.id as "column0", o.name as "column1", p.id as "column2", p.name as "column3"
+from people p inner join
+orgs o on p.id = o.id
+`)
+  })
+
+  it('converts data from result set to writeable model', async () => {
+    const swormSchema = new SwormSchema({
+      url: 'sqlite:test/db/test.db',
+      schema: {
+        people: {
+          id: {type: 'integer', primaryKey: true},
+          orgId: {type: 'integer'},
+          parentId: {type: 'integer', null: true},
+          name: {type: 'text'},
+        },
+        orgs: {
+          id: {type: 'integer', primaryKey: true},
+          name: {type: 'text'},
+        }
+      }
+    })
+    await swormSchema.create()
+    const db = swormSchema.connect()
+    const person = db.model({table: 'people'})
+    const org = db.model({table: 'orgs'})
+
+    await person({id: 1, orgId: 1, name: 'jill'}).save()
+    await person({id: 2, orgId: 1, parentId: 1, name: 'julie'}).save()
+    await org({id: 1, name: 'featurist'}).save()
+
+    const query = new SwormQuery({schema: swormSchema.schema, query: `
+      select p.name, parent.name as parent, o.name orgName
+      from people p inner join
+        orgs o on p.orgId = o.id left join
+        people parent on p.parentId = p.id
+    `})
+
+    // we'd really call this against a production db
+    const model = await query.fetchData(db)
+
+    assert.deepEqual(model, [
+      {table: 'orgs', columns: {id: 1, name: 'featurist'}},
+      {table: 'people', columns: {id: 1, orgid: 1, parentid: null, name: 'jill'}},
+      {table: 'people', columns: {id: 2, orgid: 1, parentid: 1, name: 'julie'}},
+    ])
+  })
+})

--- a/test/cleanTableSpec.js
+++ b/test/cleanTableSpec.js
@@ -1,9 +1,9 @@
 const assert = require('assert')
-const SwormSchema = require('..')
+const {Schema} = require('..')
 
 describe('clean tables', () => {
   it('removes all data from the tables', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
         people: {

--- a/test/cleanup.js
+++ b/test/cleanup.js
@@ -1,0 +1,7 @@
+const fs = require('mz/fs')
+
+beforeEach(async () => {
+  if (await fs.exists('test/db/test.db')) {
+    await fs.unlink('test/db/test.db')
+  }
+})

--- a/test/createSchemaSpec.js
+++ b/test/createSchemaSpec.js
@@ -1,9 +1,9 @@
 const assert = require('assert')
-const SwormSchema = require('..')
+const {Schema} = require('..')
 
 describe('create schema', () => {
   it('creates tables defined in the schema', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
         people: {

--- a/test/dropSchemaSpec.js
+++ b/test/dropSchemaSpec.js
@@ -1,10 +1,10 @@
 const assert = require('assert')
 const fs = require('mz/fs')
-const SwormSchema = require('..')
+const {Schema} = require('..')
 
 describe('drop schema', () => {
   it('drops tables defined in the schema', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
         people: {
@@ -37,7 +37,7 @@ describe('drop schema', () => {
   })
 
   it('dropping a database that does not exist does not result in an error', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
       }

--- a/test/validateQuerySpec.js
+++ b/test/validateQuerySpec.js
@@ -1,10 +1,10 @@
 const assert = require('assert')
 const fs = require('mz/fs')
-const SwormSchema = require('..')
+const {Schema} = require('..')
 
 describe('validate query', () => {
   it('returns no changes when the schema matches the query', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
         people: {
@@ -27,7 +27,7 @@ describe('validate query', () => {
   })
 
   it('returns the missing tables/columns when the schema does not match', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
         people: {
@@ -60,7 +60,7 @@ describe('validate query', () => {
   })
 
   it('correctly identifies columns when query with aliased tables of the same name are in a union', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {}
     })
@@ -92,7 +92,7 @@ describe('validate query', () => {
   })
 
   it('identitfies columns that are not associated with a table', async () => {
-    const swormSchema = new SwormSchema({
+    const swormSchema = new Schema({
       url: 'sqlite:test/db/test.db',
       schema: {
         people: {


### PR DESCRIPTION
When you have a legacy database that has a complex query with multiple joins and you need to run that query in a test database it can be hard to figure out what data to setup.

This PR adds support for analysing a query, figuring out what data it needs, getting that data and turning it into a model that can be easily saved into a test database using sworm.